### PR TITLE
check for gID as gNo might be duplicate (team 1196061)

### DIFF
--- a/src/H4aEventAutomator/H4aEventAutomator.php
+++ b/src/H4aEventAutomator/H4aEventAutomator.php
@@ -173,7 +173,7 @@ class H4aEventAutomator extends Backend
                         $objEvent->pid = $objCalendar->id;
                         $objEvent->tstamp = time();
                         $objEvent->title = $arrSpiel['gClassSname'].': '.$arrSpiel['gHomeTeam'].' - '.$arrSpiel['gGuestTeam'];
-                        $objEvent->alias = StringUtil::generateAlias($arrSpiel['gClassSname'].'_'.$arrSpiel['gHomeTeam'].'_'.$arrSpiel['gGuestTeam'].'_'.$arrSpiel['gNo']);
+                        $objEvent->alias = StringUtil::generateAlias($arrSpiel['gClassSname'].'_'.$arrSpiel['gHomeTeam'].'_'.$arrSpiel['gGuestTeam'].'_'.$arrSpiel['gID']);
                         $objEvent->h4a_season = $seasonID;
                         $objEvent->gGameID = $arrSpiel['gID'];
                         $objEvent->gGameNo = $arrSpiel['gNo'];

--- a/src/H4aEventAutomator/H4aEventAutomator.php
+++ b/src/H4aEventAutomator/H4aEventAutomator.php
@@ -98,9 +98,8 @@ class H4aEventAutomator extends Backend
                 // Update or Create Event
                 foreach ($arrSpiele as $arrSpiel) {
                     $objEvent = CalendarEventsModel::findOneBy(
-                        ['gGameNo=?', 'pid=?', 'gClassID=?'],
-                        [$arrSpiel['gNo'], $objCalendar->id, $arrSeason['h4a_liga']],
-                    );
+                        ['gGameNo=?', 'pid=?', 'gClassID=?', 'gGameID=?'],
+                        [$arrSpiel['gNo'], $objCalendar->id, $arrSeason['h4a_liga'], $arrSpiel['gID']],                    );
 
                     // Update, wenn ModelObjekt existiert
                     if (null !== $objEvent) {


### PR DESCRIPTION
Bei Team 1196061 gab es ein eine gam ID doppelt, daher wurde das erste Spiel mit den Daten des zweiten Spiels überschrieben. Um das zu vermeiden, wird ab sofort die gID geutzt, da diese eindeutigzu sein scheint!

TODO: Spiele werden aktuell noch nicht automatisiert gelöscht, das muss noch implementiert werden! 