### PR TITLE
Fix: Revert "Feat: use CacheTagManager instead of EntityCacheTags"

### DIFF
--- a/config/commands.yml
+++ b/config/commands.yml
@@ -11,7 +11,7 @@ services:
         class: Janborg\H4aTabellen\Command\H4aUpdateResultsCommand
         arguments:
             - '@contao.framework'
-            - '@contao.cache.tag_manager'
+            - '@contao.cache.entity_tags'
             - '@h4atabellen.handballnet.apiclient'
             - '@event_dispatcher'
 

--- a/config/controller.yml
+++ b/config/controller.yml
@@ -33,7 +33,7 @@ services:
     Janborg\H4aTabellen\Backend\UpdateH4aResultsController:
         public: true
         arguments:
-            - '@contao.cache.tag_manager'
+            - '@contao.cache.entity_tags'
             - '@h4atabellen.handballnet.apiclient'
             - '@event_dispatcher'
             - '@router'

--- a/config/services.yml
+++ b/config/services.yml
@@ -12,7 +12,7 @@ services:
         public: true
         arguments:
             - '@contao.framework'
-            - '@contao.cache.tag_manager'
+            - '@contao.cache.entity_tags'
             - '@h4atabellen.handballnet.apiclient'
             - '@?monolog.logger.contao.general'
     
@@ -30,7 +30,7 @@ services:
         class: Janborg\H4aTabellen\Cron\UpdateH4aResultsCron
         arguments:
             - '@contao.framework'
-            - '@contao.cache.tag_manager'
+            - '@contao.cache.entity_tags'
             - '@?monolog.logger.contao.cron'
             - '@h4atabellen.handballnet.apiclient'
             - '@event_dispatcher'

--- a/src/Backend/UpdateH4aResultsController.php
+++ b/src/Backend/UpdateH4aResultsController.php
@@ -15,7 +15,7 @@ namespace Janborg\H4aTabellen\Backend;
 use Contao\Backend;
 use Contao\BackendUser;
 use Contao\CalendarEventsModel;
-use Contao\CoreBundle\Cache\CacheTagManager;
+use Contao\CoreBundle\Cache\EntityCacheTags;
 use Contao\Message;
 use Janborg\H4aTabellen\Event\H4aResultUpdatedEvent;
 use Janborg\H4aTabellen\HandballnetApiClient;
@@ -25,7 +25,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 class UpdateH4aResultsController extends Backend
 {
     public function __construct(
-        private CacheTagManager $cacheTagManager,
+        private EntityCacheTags $entityCacheTags,
         private HandballnetApiClient $handballnetApiClient,
         private readonly EventDispatcherInterface $eventDispatcher,
         private UrlGeneratorInterface $urlGenerator,
@@ -80,7 +80,7 @@ class UpdateH4aResultsController extends Backend
                 Message::addConfirmation('Ergebnis ('.$data['data']['homeGoals'].':'.$data['data']['awayGoals'].' für Spiel '.$objEvent->gGameID.' '.$objEvent->title.' erhalten.');
 
                 // Invalidate CacheTag for Event
-                $this->cacheTagManager->invalidateTagsFor($objEvent);
+                $this->entityCacheTags->invalidateTagsFor($objEvent);
             } else {
                 $objEvent->h4a_resultComplete = false;
 

--- a/src/Command/H4aUpdateResultsCommand.php
+++ b/src/Command/H4aUpdateResultsCommand.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 namespace Janborg\H4aTabellen\Command;
 
 use Contao\CalendarEventsModel;
-use Contao\CoreBundle\Cache\CacheTagManager;
+use Contao\CoreBundle\Cache\EntityCacheTags;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Janborg\H4aTabellen\Event\H4aResultUpdatedEvent;
 use Janborg\H4aTabellen\HandballnetApiClient;
@@ -40,7 +40,7 @@ class H4aUpdateResultsCommand extends Command
 
     public function __construct(
         private ContaoFramework $framework,
-        private CacheTagManager $cacheTagManager,
+        private EntityCacheTags $entityCacheTags,
         private HandballnetApiClient $handballnetApiClient,
         private readonly EventDispatcherInterface $eventDispatcher,
     ) {
@@ -128,7 +128,7 @@ class H4aUpdateResultsCommand extends Command
                 $this->eventDispatcher->dispatch($event);
 
                 // Invalidate CacheTag for Event
-                $this->cacheTagManager->invalidateTagsFor($objEvent);
+                $this->entityCacheTags->invalidateTagsFor($objEvent);
             } else {
                 $objEvent->h4a_resultComplete = false;
 

--- a/src/Cron/UpdateH4aResultsCron.php
+++ b/src/Cron/UpdateH4aResultsCron.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 namespace Janborg\H4aTabellen\Cron;
 
 use Contao\CalendarEventsModel;
-use Contao\CoreBundle\Cache\CacheTagManager;
+use Contao\CoreBundle\Cache\EntityCacheTags;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Janborg\H4aTabellen\Event\H4aResultUpdatedEvent;
 use Janborg\H4aTabellen\HandballnetApiClient;
@@ -24,7 +24,7 @@ class UpdateH4aResultsCron
 {
     public function __construct(
         private ContaoFramework $framework,
-        private CacheTagManager $cacheTagManager,
+        private EntityCacheTags $entityCacheTags,
         private readonly LoggerInterface|null $logger,
         private HandballnetApiClient $handballnetApiClient,
         private readonly EventDispatcherInterface $eventDispatcher,
@@ -82,7 +82,7 @@ class UpdateH4aResultsCron
                 ;
 
                 // Invalidate CacheTag for Event
-                $this->cacheTagManager->invalidateTagsFor($objEvent);
+                $this->entityCacheTags->invalidateTagsFor($objEvent);
             } else {
                 $objEvent->h4a_resultComplete = false;
 

--- a/src/H4aEventAutomator/H4aEventAutomator.php
+++ b/src/H4aEventAutomator/H4aEventAutomator.php
@@ -15,7 +15,7 @@ namespace Janborg\H4aTabellen\H4aEventAutomator;
 use Contao\Backend;
 use Contao\CalendarEventsModel;
 use Contao\CalendarModel;
-use Contao\CoreBundle\Cache\CacheTagManager;
+use Contao\CoreBundle\Cache\EntityCacheTags;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\Input;
 use Contao\StringUtil;
@@ -30,7 +30,7 @@ class H4aEventAutomator extends Backend
 {
     public function __construct(
         private ContaoFramework $contaoFramework,
-        private CacheTagManager $cacheTagManager,
+        private EntityCacheTags $entityCacheTags,
         private HandballnetApiClient $handballnetApiClient,
         private readonly LoggerInterface|null $logger,
     ) {
@@ -223,7 +223,7 @@ class H4aEventAutomator extends Backend
                         $this->logger?->info('Event für Spiel '.$arrSpiel['tournament']['acronym'].': '.$arrSpiel['homeTeam']['name'].': '.$arrSpiel['awayTeam']['name'].' (gID: '.$objEvent->gGameID.') über Handball4all aktualisiert');
 
                         // Invalidate CacheTag for Event
-                        $this->cacheTagManager->invalidateTagsFor($objEvent);
+                        $this->entityCacheTags->invalidateTagsFor($objEvent);
                     }
 
                     // Create Event, wenn ModelObjekt existiert
@@ -282,7 +282,7 @@ class H4aEventAutomator extends Backend
                     $objEvent->save();
 
                     // Invalidate CacheTag for Event
-                    $this->cacheTagManager->invalidateTagsFor($objEvent);
+                    $this->entityCacheTags->invalidateTagsFor($objEvent);
                 }
             }
         }


### PR DESCRIPTION
Reverts janborg/contao-h4a_tabellen#134
CacheTagManager is not available in Contao 5.3