### PR TITLE
Fix: Spaltenname im Update-Cron korrigieren

### DIFF
--- a/src/Cron/UpdateH4aEventsCron.php
+++ b/src/Cron/UpdateH4aEventsCron.php
@@ -30,7 +30,7 @@ class UpdateH4aEventsCron
     public function updateEvents(): void
     {
         $objCalendars = CalendarModel::findby(
-            ['tl_calendar.hn_imported=?'],
+            ['tl_calendar.handballnet_imported=?'],
             [true],
         );
 


### PR DESCRIPTION
## Zusammenfassung
- `UpdateH4aEventsCron` filterte Kalender über die nicht existierende Spalte `hn_imported` statt `handballnet_imported`, wodurch der Cron nie Kalender fand und somit keine Events aktualisiert wurden.

## Testplan
- [ ] Cron manuell ausführen und prüfen, dass importierte Kalender gefunden und synchronisiert werden

🤖 Generated with [Claude Code](https://claude.com/claude-code)